### PR TITLE
Security is money

### DIFF
--- a/src/main/avro/boliglan.avsc
+++ b/src/main/avro/boliglan.avsc
@@ -45,8 +45,8 @@
       "type": ["null", "no.penger.export.domain.Boligdata"]
     },
     {
-      "name": "sikkerheteiendom",
-      "type": ["null", "no.penger.export.domain.Boligdata"]
+      "name": "tilleggssikkerhet",
+      "type": ["null", "no.penger.export.domain.NOK"]
     }
   ]
 }


### PR DESCRIPTION
At this time the only data we get for additional security in our boliglån-schema is the value, so this collapses to only NOK.