### PR TITLE
Adds attachment-hashes to boliglan-export

### DIFF
--- a/src/main/avro/boliglan.avsc
+++ b/src/main/avro/boliglan.avsc
@@ -49,7 +49,8 @@
       "type": ["null", "no.penger.export.domain.NOK"]
     },
     {
-      "name": "vedleggshasher",
+      "name": "vedlegg",
+      "doc": "Inneholder sha256-hasher av alle vedlegg brukeren har lastet opp",
       "type": {
         "type": "array",
         "items": {"type": "string"}

--- a/src/main/avro/boliglan.avsc
+++ b/src/main/avro/boliglan.avsc
@@ -47,6 +47,13 @@
     {
       "name": "tilleggssikkerhet",
       "type": ["null", "no.penger.export.domain.NOK"]
+    },
+    {
+      "name": "vedleggshasher",
+      "type": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
     }
   ]
 }


### PR DESCRIPTION
Boliglån needs to have the hashes of the attachments users have uploaded during the application-process. 