### PR TITLE
Remove all 'display_value' fields

### DIFF
--- a/src/main/avro/base/03_money.avsc
+++ b/src/main/avro/base/03_money.avsc
@@ -7,10 +7,6 @@
     {
       "name": "verdi",
       "type": "double"
-    },
-    {
-      "name": "display_value",
-      "type": "string"
     }
   ]
 }

--- a/src/main/avro/base/06_tidspunkt.avsc
+++ b/src/main/avro/base/06_tidspunkt.avsc
@@ -7,10 +7,6 @@
     {
       "name": "iso8601",
       "type": "string"
-    },
-    {
-      "name": "display_value",
-      "type": "string"
     }
   ]
 }

--- a/src/main/avro/base/profile.avsc
+++ b/src/main/avro/base/profile.avsc
@@ -182,10 +182,6 @@
                 "int"
               ],
               "default": null
-            },
-            {
-              "name": "display_value",
-              "type": "string"
             }
           ]
         }
@@ -211,10 +207,6 @@
               "name": "arlig_utgift",
               "doc": "Årlig utgift for denne utgiftstypen",
               "type": "no.penger.export.domain.NOK"
-            },
-            {
-              "name": "display_value",
-              "type": "string"
             }
           ]
         }
@@ -258,10 +250,6 @@
                 "int"
               ],
               "default": null
-            },
-            {
-              "name": "display_value",
-              "type": "string"
             }
           ]
         }

--- a/src/test/resources/billan-example.json
+++ b/src/test/resources/billan-example.json
@@ -10,13 +10,13 @@
       },
       "rolle": "APPLICANT",
       "fodeland": {
-        "no.penger.export.domain.Country":{
-          "iso3166":"GBR"
+        "no.penger.export.domain.Country": {
+          "iso3166": "GBR"
         }
       },
       "statsborgerskap": {
-        "no.penger.export.domain.Country":{
-          "iso3166":"NOR"
+        "no.penger.export.domain.Country": {
+          "iso3166": "NOR"
         }
       },
       "fodselsdato": {
@@ -51,27 +51,22 @@
         {
           "key": "SelvstendigNaering",
           "arlig_inntekt": {
-            "verdi": 100000,
-            "display_value": " 100 000"
+            "verdi": 100000
           },
           "ansatt_antall_ar": null,
           "arbeidsgiver": {
             "string": "Foobar"
-          },
-          "display_value": "Selvstendig næringsdrivende (ENK)"
+          }
         }
       ],
       "gjeld": [
         {
           "key": "Studielan",
           "belop": {
-            "verdi": 10,
-            "display_value": "10"
+            "verdi": 10
           },
           "rente": null,
-          "gjenstaende_ar": null,
-          "display_value": "Studielån"
-
+          "gjenstaende_ar": null
         }
       ],
       "utgift": [],
@@ -83,19 +78,17 @@
     }
   ],
   "markedsplass": "PENGER",
-  "tilbud":{
-    "tilbydernavn":"banknavn",
-    "tilbudsnavn":"Billån for unge"
+  "tilbud": {
+    "tilbydernavn": "banknavn",
+    "tilbudsnavn": "Billån for unge"
   },
   "gjenpartsbrev": "ELEKTRONISK",
   "pris": {
-    "verdi": 10,
-    "display_value": "10"
+    "verdi": 10
   },
   "nedbetalingstid": 10,
   "egenkapital": {
-    "verdi": 10,
-    "display_value": "10"
+    "verdi": 10
   },
   "finnkode": {
     "string": "112121"

--- a/src/test/resources/boliglan-example.json
+++ b/src/test/resources/boliglan-example.json
@@ -10,13 +10,13 @@
       },
       "rolle": "APPLICANT",
       "fodeland": {
-        "no.penger.export.domain.Country":{
-          "iso3166":"GBR"
+        "no.penger.export.domain.Country": {
+          "iso3166": "GBR"
         }
       },
       "statsborgerskap": {
-        "no.penger.export.domain.Country":{
-          "iso3166":"NOR"
+        "no.penger.export.domain.Country": {
+          "iso3166": "NOR"
         }
       },
       "fodselsdato": {
@@ -51,12 +51,10 @@
         {
           "key": "Arbeidstaker",
           "arlig_inntekt": {
-            "verdi": 450000,
-            "display_value": "450 000"
+            "verdi": 450000
           },
           "arbeidsgiver": null,
-          "ansatt_antall_ar": null,
-          "display_value": "Arbeidstaker"
+          "ansatt_antall_ar": null
         }
       ],
       "utgift": [],
@@ -64,12 +62,10 @@
         {
           "key": "Studielan",
           "belop": {
-            "verdi": 300000,
-            "display_value": "300 000"
+            "verdi": 300000
           },
           "rente": null,
-          "gjenstaende_ar": null,
-          "display_value": "Studielån"
+          "gjenstaende_ar": null
         }
       ],
       "fagforeninger": [
@@ -86,8 +82,8 @@
         "string": "Nordmann"
       },
       "rolle": "CO_APPLICANT",
-      "fodeland" : null,
-      "statsborgerskap" : null,
+      "fodeland": null,
+      "statsborgerskap": null,
       "fodselsdato": {
         "string": "1985-10-18"
       },
@@ -109,12 +105,10 @@
         {
           "key": "Student",
           "arlig_inntekt": {
-            "verdi": 100000,
-            "display_value": "100 000"
+            "verdi": 100000
           },
           "arbeidsgiver": null,
-          "ansatt_antall_ar": null,
-          "display_value": "Student"
+          "ansatt_antall_ar": null
         }
       ],
       "utgift": [],
@@ -123,18 +117,16 @@
     }
   ],
   "markedsplass": "FINN",
-  "tilbud":{
-    "tilbydernavn":"banknavn",
-    "tilbudsnavn":"Boliglån for unge"
+  "tilbud": {
+    "tilbydernavn": "banknavn",
+    "tilbudsnavn": "Boliglån for unge"
   },
   "nedbetalingstid": 25,
   "egenkapital": {
-    "verdi": 500000,
-    "display_value": "500 000"
+    "verdi": 500000
   },
   "laanesum": {
-    "verdi": 0,
-    "display_value": "0"
+    "verdi": 0
   },
   "laanetype": "Lån",
   "eiendom": null,
@@ -142,12 +134,10 @@
   "vedlegg": [],
   "kredittVerdig": true,
   "anbefaltLaan": {
-    "verdi": 10000,
-    "display_value": "10 000"
+    "verdi": 10000
   },
   "belaaningsGrad": 85.2,
   "mottatt": {
-    "iso8601": "2017-12-04T08:43:54.956Z",
-    "display_value": "04. desember, 2017"
+    "iso8601": "2017-12-04T08:43:54.956Z"
   }
 }

--- a/src/test/resources/forsikringspakke-example.json
+++ b/src/test/resources/forsikringspakke-example.json
@@ -75,8 +75,7 @@
           "ubegrenset": null
         },
         "egenandel": {
-          "verdi": 4000,
-          "display_value": "4 000"
+          "verdi": 4000
         },
         "yngsteSjaafoerAlderUnder25": {
           "int": 0
@@ -118,12 +117,10 @@
       "innbo": {
         "no.penger.export.domain.forsikringspakke.Innboforsikring": {
           "egenandel": {
-            "verdi": 8000,
-            "display_value": "8 000"
+            "verdi": 8000
           },
           "beloep": {
-            "verdi": 750000,
-            "display_value": "750 000"
+            "verdi": 750000
           },
           "bakkeplan": true,
           "egenInngang": false,
@@ -146,8 +143,7 @@
   },
   "kredittVerdig": true,
   "mottatt": {
-    "iso8601": "2018-05-30T12:18:28.181+02:00",
-    "display_value": "30.mai.2018 12:18:28"
+    "iso8601": "2018-05-30T12:18:28.181+02:00"
   },
   "ansattIKommuneEllerHelsesektor": false,
   "hovedforsikringsSelskap": {

--- a/src/test/resources/utleieforsikring-example.json
+++ b/src/test/resources/utleieforsikring-example.json
@@ -9,13 +9,13 @@
     },
     "rolle": "APPLICANT",
     "fodeland": {
-      "no.penger.export.domain.Country":{
-        "iso3166":"GBR"
+      "no.penger.export.domain.Country": {
+        "iso3166": "GBR"
       }
     },
     "statsborgerskap": {
-      "no.penger.export.domain.Country":{
-        "iso3166":"NOR"
+      "no.penger.export.domain.Country": {
+        "iso3166": "NOR"
       }
     },
     "fodselsdato": {
@@ -48,9 +48,9 @@
     "fagforeninger": []
   },
   "gjenpartsbrev": "ELEKTRONISK",
-  "tilbud":{
-    "tilbydernavn":"banknavn",
-    "tilbudsnavn":"Utleieforsikring under 40m2"
+  "tilbud": {
+    "tilbydernavn": "banknavn",
+    "tilbudsnavn": "Utleieforsikring under 40m2"
   },
   "utleietype": "MOBLERT",
   "adresse": "foobar",
@@ -59,18 +59,15 @@
   },
   "kvadratmeter": 10,
   "maanedsleie": {
-    "verdi": 100,
-    "display_value": "100"
+    "verdi": 100
   },
   "leiesUtFra": "2017-12-03",
   "kredittVerdig": true,
   "mottatt": {
-    "iso8601": "2017-12-04T11:05:28.954+01:00",
-    "display_value": "04.des.2017 11:05:28"
+    "iso8601": "2017-12-04T11:05:28.954+01:00"
   },
   "aarspris": {
-    "verdi": 828,
-    "display_value": "828"
+    "verdi": 828
   },
   "finnkode": {
     "kode": "8181818"


### PR DESCRIPTION
@aspic Jeg fjernet alle `display_value`s når jeg først var i gang, ikke bare på `Money`. Noen innvendinger?

Konsumenter med nytt skjema kan fortsatt lese meldinger skrevet med gammelt skjema. Vi kan derfor la partnere oppgradere i sitt eget tempo, og deretter oppgradere hos oss selv etter at alle er over.